### PR TITLE
Eliminating the use of  "invokelatest"

### DIFF
--- a/src/CharibdeOptim.jl
+++ b/src/CharibdeOptim.jl
@@ -1,8 +1,8 @@
 module CharibdeOptim
 
-export constraint, charibde_min, charibde_max, ibc_maximise, diffevol_maximise
-export ibc_minimise, diffevol_minimise
-export OptimisationProblem, solve!
+export  minimise_by_charibde, maximise_by_charibde
+export minimise_by_ibc, minimise_by_diffevol, maximise_by_ibc, maximise_by_diffevol
+export constraint, OptimisationProblem, ConstrainedOptimisationProblem
 
 using IntervalArithmetic
 using Distributed
@@ -21,14 +21,93 @@ struct OptimisationProblem{N, T}
     X::IntervalBox{N, T}
 end
 
-function solve!(prob::OptimisationProblem)
-    ibc_minimise(prob.f, prob.X)
-end
 
 struct Constraint{T}
    bound::Interval{T}
    C::Contractor
 end
+
+struct ConstrainedOptimisationProblem{N, T}
+    f::Function
+    X::IntervalBox{N, T}
+    constraints::Vector{Constraint{T}}
+end
+"""Usage:
+```
+For Unconstrained Optimsation:
+  f = X->((x,y)=X;x^3 + 2y + 5)
+  A = IntervalBox(2..4, 2..3)
+  prob = OptimisationProblem(f, A)
+
+  (global_min, minimisers, info) = minimise_by_ibc(prob)
+  (global_max, maximisers, info) = maximise_by_ibc(prob)
+  (global_min, minimisers) =  minimise_by_diffevol(prob)
+  (global_max, maximisers) = maximiser_by_diffevol(prob)
+
+For Constrained Optimisation:
+  f = X->((x,y)=X;-(x-4)^2-(y-4)^2)
+  A = IntervalBox(-4..4, -4..4)
+
+  vars = ModelingToolkit.@variables x y
+  C1 = Constraint(vars, x+y, -Inf..4)
+  C2 = Constraint(vars, x+3y, -Inf..9)
+
+  prob = ConstrainedOptimisation(f, A, [C1, C2])
+
+  (global_min, minimisers, info) = minimise_by_ibc(prob)
+  (global_max, maximisers, info) = maximise_by_diffevol(prob)
+  (global_min, minimisers) =  minimise_by_diffevol(prob)
+  (global_max, maximisers) = maximiser_by_diffevol(prob)
+
+minimise_by_ibc/maximise_by_ibc, minimise_by_diffevol/maximise_by_diffevol find the global minimum/maximum value of the function in given search space by using Interval Bound & Contract(IBC)  and Differential Evolution algorithm
+```
+"""
+function minimise_by_ibc(prob::OptimisationProblem{N, T}; ibc_chnl = RemoteChannel(()->Channel{Tuple{IntervalBox{N,T}, T}}(0)),
+               diffevol_chnl = RemoteChannel(()->Channel{Tuple{SVector{N, T}, T, Union{Nothing, IntervalBox{N, T}}}}(0)), structure = SortedVector, debug = false, tol=1e-6, ibc_ind = true) where{N, T}
+
+    vars = [Variable(Symbol("x",i))() for i in 1:length(prob.X)]
+    g(x...) = prob.f(x)
+    C = BasicContractor(vars, g)
+    invokelatest(ibc_minimise, prob.f, prob.X, C, ibc_chnl = ibc_chnl, diffevol_chnl = diffevol_chnl, structure = structure, debug = debug, tol=tol, ibc_ind = ibc_ind)
+end
+
+function maximise_by_ibc(prob::OptimisationProblem{N, T}; ibc_chnl = RemoteChannel(()->Channel{Tuple{IntervalBox{N,T}, T}}(0)),
+               diffevol_chnl = RemoteChannel(()->Channel{Tuple{SVector{N, T}, T, Union{Nothing, IntervalBox{N, T}}}}(0)), structure = SortedVector, debug = false, tol=1e-6, ibc_ind = true) where{N, T}
+    vars = [Variable(Symbol("x",i))() for i in 1:length(prob.X)]
+    g(x...) = prob.f(x)
+    C = BasicContractor(vars, g)
+    invokelatest(ibc_maximise, prob.f, prob.X, C, ibc_chnl = ibc_chnl, diffevol_chnl = diffevol_chnl, structure = structure, debug = debug, tol=tol, ibc_ind = ibc_ind)
+end
+
+function minimise_by_ibc(prob::ConstrainedOptimisationProblem{N, T}; ibc_chnl = RemoteChannel(()->Channel{Tuple{IntervalBox{N,T}, T}}(0)),
+               diffevol_chnl = RemoteChannel(()->Channel{Tuple{SVector{N, T}, T, Union{Nothing, IntervalBox{N, T}}}}(0)), structure = SortedVector, debug = false, tol=1e-6, ibc_ind = true) where{N, T}
+    vars = [Variable(Symbol("x",i))() for i in 1:length(prob.X)]
+    g(x...) = prob.f(x)
+    C = BasicContractor(vars, g)
+    invokelatest(ibc_minimise, prob.f, prob.X, prob.constraints, C, ibc_chnl = ibc_chnl, diffevol_chnl = diffevol_chnl, structure = structure, debug = debug, tol=tol, ibc_ind = ibc_ind)
+end
+
+function maximise_by_ibc(prob::ConstrainedOptimisationProblem{N, T}; ibc_chnl = RemoteChannel(()->Channel{Tuple{IntervalBox{N,T}, T}}(0)),
+               diffevol_chnl = RemoteChannel(()->Channel{Tuple{SVector{N, T}, T, Union{Nothing, IntervalBox{N, T}}}}(0)), structure = SortedVector, debug = false, tol=1e-6, ibc_ind = true) where{N, T}
+    vars = [Variable(Symbol("x",i))() for i in 1:length(prob.X)]
+    g(x...) = prob.f(x)
+    C = BasicContractor(vars, g)
+    invokelatest(ibc_maximise, prob.f, prob.X, prob.constraints, C, ibc_chnl = ibc_chnl, diffevol_chnl = diffevol_chnl, structure = structure, debug = debug, tol=tol, ibc_ind = ibc_ind)
+end
+
+
+minimise_by_diffevol(prob::OptimisationProblem{N, T}; ibc_chnl = RemoteChannel(()->Channel{Tuple{IntervalBox{N,T}, Float64}}(0)),
+               diffevol_chnl = RemoteChannel(()->Channel{Tuple{SVector{N, T}, T, Union{Nothing, IntervalBox{N, T}}}}(0)), np = 10*N, debug = false, de_ind = true, iterations = 20) where{N, T} = diffevol_minimise(prob.f, prob.X, ibc_chnl = ibc_chnl, diffevol_chnl = diffevol_chnl, np = np, debug = debug, de_ind = de_ind, iterations = iterations)
+
+maximise_by_diffevol(prob::OptimisationProblem{N, T}; ibc_chnl = RemoteChannel(()->Channel{Tuple{IntervalBox{N,T}, Float64}}(0)),
+               diffevol_chnl = RemoteChannel(()->Channel{Tuple{SVector{N, T}, T, Union{Nothing, IntervalBox{N, T}}}}(0)), np = 10*N, debug = false, de_ind = true, iterations = 20) where{N, T} = diffevol_maximise(prob.f, prob.X, ibc_chnl = ibc_chnl, diffevol_chnl = diffevol_chnl, np = np, debug = debug, de_ind = de_ind, iterations = iterations)
+
+minimise_by_diffevol(prob::ConstrainedOptimisationProblem{N, T}; ibc_chnl = RemoteChannel(()->Channel{Tuple{IntervalBox{N,T}, Float64}}(0)),
+               diffevol_chnl = RemoteChannel(()->Channel{Tuple{SVector{N, T}, T, Union{Nothing, IntervalBox{N, T}}}}(0)), np = 10*N, debug = false, de_ind = true, iterations = 20) where{N, T} = diffevol_minimise(prob.f, prob.X, prob.constraints, ibc_chnl = ibc_chnl, diffevol_chnl = diffevol_chnl, np = np, debug = debug, de_ind = de_ind, iterations = iterations)
+
+maximise_by_diffevol(prob::ConstrainedOptimisationProblem{N, T}; ibc_chnl = RemoteChannel(()->Channel{Tuple{IntervalBox{N,T}, Float64}}(0)),
+               diffevol_chnl = RemoteChannel(()->Channel{Tuple{SVector{N, T}, T, Union{Nothing, IntervalBox{N, T}}}}(0)), np = 10*N, debug = false, de_ind = true, iterations = 20) where{N, T} = diffevol_maximise(prob.f, prob.X, prob.constraints, ibc_chnl = ibc_chnl, diffevol_chnl = diffevol_chnl, np = np, debug = debug, de_ind = de_ind, iterations = iterations)
+
 
 function constraint(vars, constraint_expr::Operation, bound::Interval{T}; epsilon = 1e-4) where{T}
    C = Contractor(vars, constraint_expr)
@@ -66,14 +145,15 @@ end
 ```
 f = X->((x,y)=X;x^3 + 2y + 5)
 A = IntervalBox(2..4, 2..3)
-(global_min, minimisers, info) = charibde_min(f, A)
-(global_max, maximisers, info) = charibde_max(f, A)
+prob = OptimisationProblem(f, A)
+(global_min, minimisers, info) = minimise_by_charibde(prob)
+(global_max, maximisers, info) = maximise_by_charibde(prob)
 
 charibde_min/charibde_max find the global minimum/maximum value of the function in given search space by using two algorithms Interval Bound & Contract(IBC) and Differential Evolution inparallel
 TODO: Fix the parallel implementation of charibde_min/max for Constrained Optimisation
 ```
 """
-function charibde_min(f::Function, X::IntervalBox{N,T}; workers = 2, tol = 1e-6, np = N*10, debug = false) where{N,T}
+function minimise_by_charibde(prob::OptimisationProblem{N, T}; workers = 2, tol = 1e-6, np = N*10, debug = false) where{N,T}
 
     worker_ids = Distributed.workers()
     if workers > 1
@@ -81,22 +161,22 @@ function charibde_min(f::Function, X::IntervalBox{N,T}; workers = 2, tol = 1e-6,
             error("Not enough workers available: Add one worker and load the package on it")
         end
 
-        (chnl1, chnl2) = create_channels(X, workers)                     #IBC recieve element from chnl1 and DiffEvolution from chnl2
+        (chnl1, chnl2) = create_channels(prob.X, workers)                     #IBC recieve element from chnl1 and DiffEvolution from chnl2
 
-        r1 = remotecall(diffevol_minimise, worker_ids[1], f, X, chnl1, chnl2, np = np, de_ind = false)
-        r2 = remotecall(ibc_minimise, worker_ids[2], f, X, ibc_chnl = chnl1, diffevol_chnl = chnl2, tol = tol, debug = debug, ibc_ind = false)
+        r1 = remotecall(minimise_by_diffevol, worker_ids[1], prob, chnl1, chnl2, np = np, de_ind = false)
+        r2 = remotecall(minimise_by_ibc, worker_ids[2], prob, ibc_chnl = chnl1, diffevol_chnl = chnl2, tol = tol, debug = debug, ibc_ind = false)
         return fetch(r2)
     else
-        (chnl1, chnl2) = create_channels(X, workers)
+        (chnl1, chnl2) = create_channels(prob.X, workers)
 
-        r1 = @async diffevol_minimise(f, X, chnl1, chnl2, np = np, de_ind = false)
-        r2 = @async ibc_minimise(f, X, ibc_chnl = chnl1, diffevol_chnl = chnl2, tol = tol, debug = debug, ibc_ind = false)
+        r1 = @async minimise_by_diffevol(prob, chnl1, chnl2, np = np, de_ind = false)
+        r2 = @async minimise_by_ibc(prob, ibc_chnl = chnl1, diffevol_chnl = chnl2, tol = tol, debug = debug, ibc_ind = false)
         return fetch(r2)
     end
 end
 
 
-function charibde_min(f::Function, X::IntervalBox{N,T}, constraints::Vector{Constraint{T}}; workers = 2, tol = 1e-6, np = N*10, debug = false) where{N,T}
+function minimise_by_charibde(prob::ConstrainedOptimisationProblem{N, T}; workers = 2, tol = 1e-6, np = N*10, debug = false) where{N,T}
 
     worker_ids = Distributed.workers()
     if workers > 1
@@ -104,28 +184,30 @@ function charibde_min(f::Function, X::IntervalBox{N,T}, constraints::Vector{Cons
             error("Not enough workers available: Session should have atleast 2 workers more")
         end
 
-        (chnl1, chnl2) = create_channels(X, workers)
+        (chnl1, chnl2) = create_channels(prob.X, workers)
 
-        r1 = remotecall(diffevol_minimise, worker_ids[1], f, X, constraints, ibc_chnl = chnl1, diffevol_chnl = chnl2, np = np, de_ind = false)
-        r2 = remotecall(ibc_minimise, worker_ids[2], f, X, constraints, ibc_chnl = chnl1, diffevol_chnl = chnl2, tol = tol, debug = debug, ibc_ind = false)
+        r1 = remotecall(minimise_by_diffevol, worker_ids[1], prob, ibc_chnl = chnl1, diffevol_chnl = chnl2, np = np, de_ind = false)
+        r2 = remotecall(minimise_by_ibc, worker_ids[2], prob, ibc_chnl = chnl1, diffevol_chnl = chnl2, tol = tol, debug = debug, ibc_ind = false)
         return fetch(r2)
     else
         (chnl1, chnl2) = create_channels(X, workers)
 
-        r1 = @async diffevol_minimise(f, X, constraints, ibc_chnl = chnl1, diffevol_chnl = chnl2, np = np, de_ind = false)
-        r2 = @async ibc_minimise(f, X, constraints, ibc_chnl = chnl1, diffevol_chnl = chnl2, tol= tol, debug = debug, ibc_ind = false)
+        r1 = @async minimise_by_diffevol(prob, ibc_chnl = chnl1, diffevol_chnl = chnl2, np = np, de_ind = false)
+        r2 = @async minimise_by_ibc(prob, ibc_chnl = chnl1, diffevol_chnl = chnl2, tol= tol, debug = debug, ibc_ind = false)
         return fetch(r2)
     end
 end
 
 
-function charibde_max(f::Function, X::IntervalBox{N,T}; workers = 2, tol = 1e-6, np = N*10, debug = false) where{N,T}
-    bound, minimizers, info = charibde_min(x -> -f(x), X, workers = workers, tol = tol, np = np, debug = debug)
+function maximise_by_charibde(prob::OptimisationProblem{N, T}; workers = 2, tol = 1e-6, np = N*10, debug = false) where{N,T}
+    new_prob = OptimisationProblem(x -> -prob.f(x), prob.X)
+    bound, minimizers, info = minimise_by_charibde(new_prob, workers = workers, tol = tol, np = np, debug = debug)
     return -bound, minimizers, info
 end
 
-function charibde_max(f::Function, X::IntervalBox{N,T}, constraints::Vector{Constraint{T}}; workers = 2, tol = 1e-6, np = N*10, debug = false) where{N,T}
-    bound, minimizers, info = charibde_min(x -> -f(x), X, constraints, workers = workers, tol = tol, np = np, debug = debug)
+function maximise_by_charibde(prob::ConstrainedOptimisationProblem{N, T}; workers = 2, tol = 1e-6, np = N*10, debug = false) where{N,T}
+    new_prob = ConstrainedOptimisationProblem(x-> -prob.f(x), prob.X, prob.constraints)
+    bound, minimizers, info = minimise_by_charibde(new_prob, workers = workers, tol = tol, np = np, debug = debug)
     return -bound, minimizers, info
 end
 

--- a/src/CharibdeOptim.jl
+++ b/src/CharibdeOptim.jl
@@ -2,6 +2,7 @@ module CharibdeOptim
 
 export constraint, charibde_min, charibde_max, ibc_maximise, diffevol_maximise
 export ibc_minimise, diffevol_minimise
+export OptimisationProblem, solve!
 
 using IntervalArithmetic
 using Distributed
@@ -14,6 +15,15 @@ using MacroTools
 
 import Base: invokelatest, push!
 import ForwardDiff: gradient
+
+struct OptimisationProblem{N, T}
+    f::Function
+    X::IntervalBox{N, T}
+end
+
+function solve!(prob::OptimisationProblem)
+    ibc_minimise(prob.f, prob.X)
+end
 
 struct Constraint{T}
    bound::Interval{T}

--- a/src/CharibdeOptim.jl
+++ b/src/CharibdeOptim.jl
@@ -73,14 +73,14 @@ function charibde_min(f::Function, X::IntervalBox{N,T}; workers = 2, tol = 1e-6,
 
         (chnl1, chnl2) = create_channels(X, workers)                     #IBC recieve element from chnl1 and DiffEvolution from chnl2
 
-        r1 = remotecall(diffevol_minimise, worker_ids[1], f, X, chnl1, chnl2, np = np)
-        r2 = remotecall(ibc_minimise, worker_ids[2], f, X, ibc_chnl = chnl1, diffevol_chnl = chnl2, tol = tol, debug = debug)
+        r1 = remotecall(diffevol_minimise, worker_ids[1], f, X, chnl1, chnl2, np = np, de_ind = false)
+        r2 = remotecall(ibc_minimise, worker_ids[2], f, X, ibc_chnl = chnl1, diffevol_chnl = chnl2, tol = tol, debug = debug, ibc_ind = false)
         return fetch(r2)
     else
         (chnl1, chnl2) = create_channels(X, workers)
 
-        r1 = @async diffevol_minimise(f, X, chnl1, chnl2, np = np)
-        r2 = @async ibc_minimise(f, X, ibc_chnl = chnl1, diffevol_chnl = chnl2, tol = tol, debug = debug)
+        r1 = @async diffevol_minimise(f, X, chnl1, chnl2, np = np, de_ind = false)
+        r2 = @async ibc_minimise(f, X, ibc_chnl = chnl1, diffevol_chnl = chnl2, tol = tol, debug = debug, ibc_ind = false)
         return fetch(r2)
     end
 end
@@ -96,14 +96,14 @@ function charibde_min(f::Function, X::IntervalBox{N,T}, constraints::Vector{Cons
 
         (chnl1, chnl2) = create_channels(X, workers)
 
-        r1 = remotecall(diffevol_minimise, worker_ids[1], f, X, constraints, chnl1, chnl2, np = np)
-        r2 = remotecall(ibc_minimise, worker_ids[2], f, X, constraints, ibc_chnl = chnl1, diffevol_chnl = chnl2, tol = tol, debug = debug)
+        r1 = remotecall(diffevol_minimise, worker_ids[1], f, X, constraints, ibc_chnl = chnl1, diffevol_chnl = chnl2, np = np, de_ind = false)
+        r2 = remotecall(ibc_minimise, worker_ids[2], f, X, constraints, ibc_chnl = chnl1, diffevol_chnl = chnl2, tol = tol, debug = debug, ibc_ind = false)
         return fetch(r2)
     else
         (chnl1, chnl2) = create_channels(X, workers)
 
-        r1 = @async diffevol_minimise(f, X, constraints, chnl1, chnl2, np = np)
-        r2 = @async ibc_minimise(f, X, constraints, ibc_chnl = chnl1, diffevol_chnl = chnl2, tol= tol, debug = debug)
+        r1 = @async diffevol_minimise(f, X, constraints, ibc_chnl = chnl1, diffevol_chnl = chnl2, np = np, de_ind = false)
+        r2 = @async ibc_minimise(f, X, constraints, ibc_chnl = chnl1, diffevol_chnl = chnl2, tol= tol, debug = debug, ibc_ind = false)
         return fetch(r2)
     end
 end

--- a/src/ConstrainedDifferentialEvolution.jl
+++ b/src/ConstrainedDifferentialEvolution.jl
@@ -58,10 +58,10 @@ function diffevol_minimise(f::Function, X::IntervalBox{N, T}, constraints::Vecto
          (c1, c2) = (0, 0)
 
          for constraint in constraints
-            if invokelatest(constraint.C, m) ∈ constraint.bound
+            if constraint.C(m) ∈ constraint.bound
                c1 = c1 + 1
             end
-            if invokelatest(constraint.C, pop[i]) ∈ constraint.bound
+            if constraint.C(pop[i]) ∈ constraint.bound
                c2 = c2 + 1
             end
          end

--- a/src/ConstrainedDifferentialEvolution.jl
+++ b/src/ConstrainedDifferentialEvolution.jl
@@ -1,5 +1,5 @@
-function diffevol_minimise(f::Function, X::IntervalBox{N, T}, constraints::Vector{Constraint{T}}, ibc_chnl::Union{Channel{Tuple{IntervalBox{N,T}, T}}, RemoteChannel{Channel{Tuple{IntervalBox{N,T}, T}}} },
-               diffevol_chnl::Union{Channel{Tuple{SVector{N, T}, T, Union{Nothing, IntervalBox{N, T}}}}, RemoteChannel{Channel{Tuple{SVector{N, T}, T, Union{Nothing, IntervalBox{N, T}}}}}}; np = 10*N, debug = false ) where{N, T}
+function diffevol_minimise(f::Function, X::IntervalBox{N, T}, constraints::Vector{Constraint{T}}; ibc_chnl = RemoteChannel(()->Channel{Tuple{IntervalBox{N,T}, Float64}}(0)),
+               diffevol_chnl = RemoteChannel(()->Channel{Tuple{SVector{N, T}, T, Union{Nothing, IntervalBox{N, T}}}}(0)), np = 10*N, debug = false, de_ind = true, iterations = 20) where{N, T}
 
    pop = SVector{N, T}[]
 
@@ -11,6 +11,8 @@ function diffevol_minimise(f::Function, X::IntervalBox{N, T}, constraints::Vecto
    global_min = Inf
    x_best = pop[np]
 
+   num_of_iterations = 0
+
    while true
 
       fac = 2*rand()
@@ -20,19 +22,21 @@ function diffevol_minimise(f::Function, X::IntervalBox{N, T}, constraints::Vecto
 
       temp = global_min
 
-      if isready(diffevol_chnl)
-         (x_best, temp, new_box) = take!(diffevol_chnl)  # Receiveing best individual from diffevol_minimise
-         if debug
-            println("Box recevied from IBC: ", (x_best, temp))
+      if !de_ind
+         if isready(diffevol_chnl)
+            (x_best, temp, new_box) = take!(diffevol_chnl)  # Receiveing best individual from diffevol_minimise
+            if debug
+               println("Box recevied from IBC: ", (x_best, temp))
+            end
+            if temp == Inf
+               break
+            end
+            if new_box != nothing
+               X = new_box
+            end
+            push!(pop, x_best)
+            np = np + 1
          end
-         if temp == Inf
-            break
-         end
-         if new_box != nothing
-            X = new_box
-         end
-         push!(pop, x_best)
-         np = np + 1
       end
 
       for i in 1:np
@@ -86,19 +90,30 @@ function diffevol_minimise(f::Function, X::IntervalBox{N, T}, constraints::Vecto
 
       if global_min < temp
          best_box = (IntervalBox(Interval.(x_best)), global_min)
-         put!(ibc_chnl, best_box)   #sending the best individual to ibc_minimise
+         if !de_ind
+            put!(ibc_chnl, best_box)   #sending the best individual to ibc_minimise
+         end
          if debug
             println("Box send to IBC: ", best_box)
          end
       end
 
       pop = pop_new
+
+      num_of_iterations = num_of_iterations + 1
+
+      if de_ind
+         if num_of_iterations == iterations
+            return (global_min, IntervalBox(Interval.(x_best)))
+         end
+      end
+
    end
 
 end
 
-function diffevol_maximise(f::Function, X::IntervalBox{N, T}, constraints::Vector{Constraint{T}}, ibc_chnl::Union{Channel{Tuple{IntervalBox{N,T}, T}}, RemoteChannel{Channel{Tuple{IntervalBox{N,T}, T}}} },
-               diffevol_chnl::Union{Channel{Tuple{SVector{N, T}, T, Union{Nothing, IntervalBox{N, T}}}}, RemoteChannel{Channel{Tuple{SVector{N, T}, T, Union{Nothing, IntervalBox{N, T}}}}}}; np = 10*N, debug = false ) where{N, T}
+function diffevol_maximise(f::Function, X::IntervalBox{N, T}, constraints::Vector{Constraint{T}}; ibc_chnl = RemoteChannel(()->Channel{Tuple{IntervalBox{N,T}, Float64}}(0)),
+               diffevol_chnl = RemoteChannel(()->Channel{Tuple{SVector{N, T}, T, Union{Nothing, IntervalBox{N, T}}}}(0)), np = 10*N, debug = false, de_ind = true, iterations = 20) where{N, T}
 
-            diffevol_minimise(x -> -f(x), X, constraints, ibc_chnl, diffevol_chnl, np = np, debug = debug)
-         end
+   diffevol_minimise(x -> -f(x), X, constraints, ibc_chnl = ibc_chnl, diffevol_chnl = diffevol_chnl, np = np, debug = debug, de_ind = de_ind, iterations = iterations)
+end

--- a/src/IBC.jl
+++ b/src/IBC.jl
@@ -71,7 +71,8 @@ function ibc_minimise(f::Function , X::IntervalBox{N,T}; ibc_chnl = RemoteChanne
         end
 
         A = -∞..global_min
-        X = invokelatest(C, A, X)                        # Contracting the box by constraint f(X) < globla_min
+        #X = invokelatest(C, A, X)                        # Contracting the box by constraint f(X) < globla_min
+        X = C(A, X)
         X_min = inf(f(X))
 
         if debug

--- a/src/IBC.jl
+++ b/src/IBC.jl
@@ -1,31 +1,8 @@
-"""Usage:
-```
-For Unconstrained Optimsation:
-  f = X->((x,y)=X;x^3 + 2y + 5)
-  A = IntervalBox(2..4, 2..3)
-  (global_min, minimisers, info) = ibc_minimise(f, A)
-  (global_max, maximisers, info) = ibc_maximise(f, A)
 
-For Constrained Optimisation:
-  f = X->((x,y)=X;-(x-4)^2-(y-4)^2)
-  A = IntervalBox(-4..4, -4..4)
-
-  vars = ModelingToolkit.@variables x y
-  C1 = Constraint(vars, x+y, -Inf..4)
-  C2 = Constraint(vars, x+3y, -Inf..9)
-
-  (global_min, minimisers, info) = ibc_minimise(f, A, [C1, C2])
-  (global_max, maximisers, info) = ibc_maximise(f, A, [C1, C2])
-
-ibc_minimise/ibc_maximise find the global minimum/maximum value of the function in given search space by using Interval Bound & Contract(IBC) algorithm
-```
-"""
-function ibc_minimise(f::Function , X::IntervalBox{N,T}; ibc_chnl = RemoteChannel(()->Channel{Tuple{IntervalBox{N,T}, T}}(0)),
+function ibc_minimise(f::Function , X::IntervalBox{N,T}, C::BasicContractor; ibc_chnl = RemoteChannel(()->Channel{Tuple{IntervalBox{N,T}, T}}(0)),
                diffevol_chnl = RemoteChannel(()->Channel{Tuple{SVector{N, T}, T, Union{Nothing, IntervalBox{N, T}}}}(0)), debug = false, structure = SortedVector, tol=1e-6, ibc_ind = true) where{N, T}
 
-    vars = [Variable(Symbol("x",i))() for i in 1:length(X)]
-    g(x...) = f(x)
-    C = BasicContractor(vars, g)
+
 
 
     working = structure([(X, inf(f(X)))], x->x[2]) # list of boxes with corresponding lower bound, arranged according to selected structure :
@@ -141,8 +118,8 @@ function ibc_minimise(f::Function , X::IntervalBox{N,T}; ibc_chnl = RemoteChanne
 
 end
 
-function ibc_maximise(f::Function , X::IntervalBox{N,T}; ibc_chnl = RemoteChannel(()->Channel{Tuple{IntervalBox{N,T}, T}}(0)),
+function ibc_maximise(f::Function , X::IntervalBox{N,T}, C::BasicContractor; ibc_chnl = RemoteChannel(()->Channel{Tuple{IntervalBox{N,T}, T}}(0)),
                diffevol_chnl = RemoteChannel(()->Channel{Tuple{SVector{N, T}, T, Union{Nothing, IntervalBox{N, T}}}}(0)), debug = false, structure = SortedVector, tol=1e-6, ibc_ind = true) where{N, T}
-    bound, minimizer, info = ibc_minimise(x -> -f(x), X, ibc_chnl = ibc_chnl, diffevol_chnl = diffevol_chnl, debug = debug, structure = structure, tol = tol, ibc_ind = true)
+    bound, minimizer, info = ibc_minimise(x -> -f(x), X, C, ibc_chnl = ibc_chnl, diffevol_chnl = diffevol_chnl, debug = debug, structure = structure, tol = tol, ibc_ind = true)
     return -bound, minimizer, info
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,46 +12,38 @@ addprocs(2)
       @everywhere C1 = constraint(vars, x+y, -Inf..4)
       @everywhere C2 = constraint(vars, x+3y, -Inf..9)
       @everywhere constraints = [C1, C2]
-      (maxima, maximisers, info) = charibde_max(X->((x,y)=X;-(x-4)^2-(y-4)^2), IntervalBox(-4..4, -4..4), constraints)
+
+      prob = ConstrainedOptimisationProblem(X->((x,y)=X;-(x-4)^2-(y-4)^2), IntervalBox(-4..4, -4..4), constraints)
+      maxima, maximisers, info = maximise_by_charibde(prob)
       @test maxima ⊆ -8.01 .. -7.99
       @test maximisers[1] ⊆ (1.99 .. 2.01) × (1.99 .. 2.01)
 end
 
-@testset "Using JuMP syntax for Constrained Optimisation" begin
-      model = Model(with_optimizer(CharibdeOptim.Optimizer))
-      @variable(model, -4 <= x <= 4)
-      @variable(model, -4 <= y <= 4)
-      @NLconstraint(model, x+y<=4)
-      @NLconstraint(model, 5<=x+3y<=9)
-      @NLobjective(model, Max, -(x-4)^2-(y-4)^2)
-      optimize!(model)
-
-      @test JuMP.termination_status(model) == MOI.OPTIMAL
-      @test JuMP.primal_status(model) == MOI.FEASIBLE_POINT
-      @test JuMP.objective_value(model) ⊆ -8.01 .. -7.99
-      @test JuMP.value(x) ⊆ (1.99 .. 2.01)
-      @test JuMP.value(y) ⊆ (1.99 .. 2.01)
-end
 
 @testset "Using Interval bound and contract algorithm for Constrained Optimisation" begin
       vars = ModelingToolkit.@variables x y
       C1 = constraint(vars, x+y, -Inf..4)
       C2 = constraint(vars, x+3y, -Inf..9)
 
-      (maxima, maximisers, info) = ibc_maximise(X->((x,y)=X;-(x-4)^2-(y-4)^2), IntervalBox(-4..4, -4..4),[C1, C2])
+      prob = ConstrainedOptimisationProblem(X->((x,y)=X;-(x-4)^2-(y-4)^2), IntervalBox(-4..4, -4..4), [C1, C2])
+      (maxima, maximisers, info) = maximise_by_ibc(prob)
       @test maxima ⊆ -8.01 .. -7.99
       @test maximisers[1] ⊆ (1.99 .. 2.01) × (1.99 .. 2.01)
 end
 
 
 @testset "Optimising by Interval Branch and Contract Algorithm" begin
-      (global_min, minimisers)= ibc_minimise(X->((x,y)= X;x^2 + y^2), IntervalBox(2..3, 3..4))
+
+      prob = OptimisationProblem(X->((x,y)= X;x^2 + y^2), IntervalBox(2..3, 3..4))
+
+      (global_min, minimisers)= minimise_by_ibc(prob)
       @test global_min ⊆ 13 .. 13.01
       @test minimisers[1] ⊆ (2.0 .. 2.001) × (3.0 .. 3.001)
 end
 
 @testset "Optimising by Differencial Evolution" begin
-      (global_min, minimiser)= diffevol_minimise(X->((x,y)= X;x^2 + y^2), IntervalBox(2..3, 3..4), iterations = 40)
+      prob = OptimisationProblem(X->((x,y)= X;x^2 + y^2), IntervalBox(2..3, 3..4))
+      (global_min, minimiser)= minimise_by_diffevol(prob, iterations = 40)
       @test global_min ⊆ 13 .. 13.01
       @test minimiser ⊆ (2.0 .. 2.001) × (3.0 .. 3.001)
 end
@@ -59,11 +51,13 @@ end
 
 @testset "Optimising by Charibde (A hybrid approach) using only one worker" begin
 
-      (global_min, minimisers, info) = charibde_min(X->((x,y)=X;x^2+y+1), IntervalBox(1..2, 2..3), workers = 1)
+      prob = OptimisationProblem(X->((x,y)=X;x^2+y+1), IntervalBox(1..2, 2..3))
+      (global_min, minimisers, info) = minimise_by_charibde(prob, workers = 1)
       @test global_min ⊆ 4.0 .. 4.01
       @test minimisers[1] ⊆ (1..1.001) × (2..2.001)
 
-      (global_min, minimisers, info)= charibde_min(X->((x,y)=X;x^2 + y^2), IntervalBox(2..3, 3..4), workers = 1)
+      prob = OptimisationProblem(X->((x,y)=X;x^2 + y^2), IntervalBox(2..3, 3..4))
+      (global_min, minimisers, info)= minimise_by_charibde(prob, workers = 1)
       @test global_min ⊆ 13 .. 13.01
       @test minimisers[1] ⊆ (2.0 .. 2.001) × (3..3.001)
 end
@@ -89,11 +83,14 @@ end
  # by '@everywhere using CharibdeOptim'.
 
 @testset "Optimising by Charibde (A hybrid approach) using 2 workers" begin
-      (global_min, minimisers, info) = charibde_min(X->((x,y)=X;x^3 + 2y + 5), IntervalBox(2..4, 2..3))
+
+      prob = OptimisationProblem(X->((x,y)=X;x^3 + 2y + 5), IntervalBox(2..4, 2..3))
+      (global_min, minimisers, info) = minimise_by_charibde(prob)
       @test global_min ⊆ 17.0 .. 17.01
       @test minimisers[1] ⊆ (2..2.001) × (2..2.001)
 
-      (global_min, minimisers, info)= charibde_min(X->((x,y)=X;x^2 + y^2), IntervalBox(2..3, 3..4))
+      prob = OptimisationProblem(X->((x,y)=X;x^2 + y^2), IntervalBox(2..3, 3..4))
+      (global_min, minimisers, info)= minimise_by_charibde(prob)
       @test global_min ⊆ 13 .. 13.01
       @test minimisers[1] ⊆ (2.0 .. 2.001) × (3..3.001)
 
@@ -134,7 +131,9 @@ end
 @testset "Optimising difficult problems using Charibde" begin
       f = X->((x1,x2,x3,x4,x5,x6,x7,x8,x9)=X;x1^2 + x2^2 + x3^4 - x4^7 - 200x5 - x6^5 - x7^9 + x8^5 - 8x9^3)
       X = IntervalBox(2..3, 3..4, 9..14, 2..3, 3..4, 9..14, 2..3, 3..4, 9..14)
-      (global_min, minimisers, info) = charibde_min(f, X)
+
+      prob = OptimisationProblem(f, X)
+      (global_min, minimisers, info) = minimise_by_charibde(prob)
 
       @test global_min ⊆ -575630 .. -575628
       @test minimisers[1] ⊆ (1.99 .. 2.01) × (2.99 .. 3.01) × (8.99 .. 9.01) × (2.99 .. 3.01) × (3.99 .. 4.01) × (13.99 .. 14.01) × (2.99 .. 3.01) × (2.99 .. 3.01) × (13.99 .. 14.01)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,7 @@ end
       @test JuMP.objective_value(model) ⊆ -8.01 .. -7.99
       @test JuMP.value(x) ⊆ (1.99 .. 2.01)
       @test JuMP.value(y) ⊆ (1.99 .. 2.01)
-end        
+end
 
 @testset "Using Interval bound and contract algorithm for Constrained Optimisation" begin
       vars = ModelingToolkit.@variables x y
@@ -48,6 +48,12 @@ end
       (global_min, minimisers)= ibc_minimise(X->((x,y)= X;x^2 + y^2), IntervalBox(2..3, 3..4))
       @test global_min ⊆ 13 .. 13.01
       @test minimisers[1] ⊆ (2.0 .. 2.001) × (3.0 .. 3.001)
+end
+
+@testset "Optimising by Differencial Evolution" begin
+      (global_min, minimiser)= diffevol_minimise(X->((x,y)= X;x^2 + y^2), IntervalBox(2..3, 3..4), iterations = 40)
+      @test global_min ⊆ 13 .. 13.01
+      @test minimiser ⊆ (2.0 .. 2.001) × (3.0 .. 3.001)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,25 +63,6 @@ end
 end
 
 
-@testset "Using JuMP syntax by using only one worker " begin           #for using two workers just dont pass 'workers' arguments as its value is set to 2
-      model = Model(with_optimizer(CharibdeOptim.Optimizer, workers = 1))
-      @variable(model, 1<=x<=2)
-      @variable(model, 1<=y<=2)
-      @NLobjective(model, Min, x^2+y^2)
-      optimize!(model)
-
-      @test JuMP.termination_status(model) == MOI.OPTIMAL
-      @test JuMP.primal_status(model) == MOI.FEASIBLE_POINT
-      @test JuMP.objective_value(model) ≈ 2.0
-      @test JuMP.value(x) ≈ 1.0
-      @test JuMP.value(y) ≈ 1.0
-end
-
-
- # No need to add worker because a worker is already added while running testset "Using Charibde for Constrained Optimsation".
- # Otherwise we have to add a worker by using 'Distributed.addprocs(1)' and load the package on each worker
- # by '@everywhere using CharibdeOptim'.
-
 @testset "Optimising by Charibde (A hybrid approach) using 2 workers" begin
 
       prob = OptimisationProblem(X->((x,y)=X;x^3 + 2y + 5), IntervalBox(2..4, 2..3))
@@ -94,38 +75,6 @@ end
       @test global_min ⊆ 13 .. 13.01
       @test minimisers[1] ⊆ (2.0 .. 2.001) × (3..3.001)
 
-end
-
-
-@testset "Optimising difficult problem using JuMP" begin
-      model = Model(with_optimizer(CharibdeOptim.Optimizer))
-
-      @variable(model, 2 <= x1 <= 3)
-      @variable(model, 3 <= x2 <= 4)
-      @variable(model, 9 <= x3 <= 14)
-      @variable(model, 2 <= x4 <= 3)
-      @variable(model, 3 <= x5 <= 4)
-      @variable(model, 9 <= x6 <= 14)
-      @variable(model, 2 <= x7 <= 3)
-      @variable(model, 3 <= x8 <= 4)
-      @variable(model, 9 <= x9 <= 14)
-
-      @NLobjective(model, Min, x1^2 + x2^2 + x3^4 - x4^7 - 200x5 - x6^5 - x7^9 + x8^5 - 8x9^3)
-
-      optimize!(model)
-
-      @test JuMP.termination_status(model) == MOI.OPTIMAL
-      @test JuMP.primal_status(model) == MOI.FEASIBLE_POINT
-      @test JuMP.objective_value(model) ≈ -575629.0
-      @test JuMP.value(x1) ⊆ 1.99 .. 2.01
-      @test JuMP.value(x2) ⊆ 2.99 .. 3.01
-      @test JuMP.value(x3) ⊆ 8.99 .. 9.01
-      @test JuMP.value(x4) ⊆ 2.99 .. 3.01
-      @test JuMP.value(x5) ⊆ 3.99 .. 4.01
-      @test JuMP.value(x6) ⊆ 13.99 .. 14.01
-      @test JuMP.value(x7) ⊆ 2.99 .. 3.01
-      @test JuMP.value(x8) ⊆ 2.99 .. 3.01
-      @test JuMP.value(x9) ⊆ 13.99 .. 14.01
 end
 
 @testset "Optimising difficult problems using Charibde" begin


### PR DESCRIPTION
In the commit "testing on ibc_minimise", I tried a way as @dpsanders proposed in issue [#48](https://github.com/JuliaIntervals/CharibdeOptim.jl/issues/48) to eliminate the use of "Invokelatest".

I tried it just on "ibc_minimise" but it still giving  the same world age error.